### PR TITLE
last seen Active #34

### DIFF
--- a/apps/backend/prisma/migrations/20250524234304_add_last_activity/migration.sql
+++ b/apps/backend/prisma/migrations/20250524234304_add_last_activity/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastActivityAt" TIMESTAMP(3);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -14,19 +14,20 @@ datasource db {
 }
 
 model User {
-  id           Int        @id @default(autoincrement())
-  name         String
-  email        String     @unique
-  bio          String?
-  avatar       String?
-  password     String?
-  isOnline     Boolean    @default(false)
-  status       UserStatus @default(OFFLINE)
-  lastSeen     DateTime?
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  isBanned     Boolean    @default(false)
-  banExpiresAt DateTime?
+  id             Int        @id @default(autoincrement())
+  name           String
+  email          String     @unique
+  bio            String?
+  avatar         String?
+  password       String?
+  isOnline       Boolean    @default(false)
+  status         UserStatus @default(OFFLINE)
+  lastSeen       DateTime?
+  lastActivityAt DateTime?
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+  isBanned       Boolean    @default(false)
+  banExpiresAt   DateTime?
 }
 
 enum UserStatus {

--- a/apps/backend/src/gateway/presence/presence.gateway.ts
+++ b/apps/backend/src/gateway/presence/presence.gateway.ts
@@ -49,6 +49,7 @@ export class PresenceGateway
           isOnline: true,
           status: 'ONLINE',
           lastSeen: null,
+          lastActivityAt: null,
         },
       });
 
@@ -72,6 +73,7 @@ export class PresenceGateway
         isOnline: false,
         status: 'OFFLINE',
         lastSeen: new Date(),
+        lastActivityAt: null,
       },
     });
     console.log('PresenceGateway: handleDisconnect', userId);
@@ -88,6 +90,7 @@ export class PresenceGateway
       data: {
         status: 'AWAY',
         isOnline: true,
+        lastActivityAt: new Date(),
       },
     });
     console.log('PresenceGateway: handleAfk', userId);


### PR DESCRIPTION
This pull request introduces a new `lastActivityAt` field to the `User` model to track user activity timestamps. Changes span database schema updates, model adjustments, and updates to the `PresenceGateway` class to handle this new field appropriately.

### Database Schema Changes:
* Added a `lastActivityAt` column to the `User` table in the database schema to store the timestamp of the user's last activity. (`apps/backend/prisma/migrations/20250524234304_add_last_activity/migration.sql`, [apps/backend/prisma/migrations/20250524234304_add_last_activity/migration.sqlR1-R2](diffhunk://#diff-9a23bc4fd6e2a783286945799d5736cf3b15da36a06941723521889eb22c549eR1-R2))

### Model Updates:
* Updated the `User` model in `schema.prisma` to include the new `lastActivityAt` field as an optional `DateTime`. (`apps/backend/prisma/schema.prisma`, [apps/backend/prisma/schema.prismaR26](diffhunk://#diff-8ce01239249acace801a09d07aaffa847a31687655eebfa2f3715a2f182bc4a7R26))

### Backend Logic Updates:
* Updated the `PresenceGateway` class to handle the new `lastActivityAt` field:
  - Set `lastActivityAt` to `null` when a user connects or disconnects. (`apps/backend/src/gateway/presence/presence.gateway.ts`, [[1]](diffhunk://#diff-47b2737085ae43569ca14a3165dc0f465cea7f01e8d786c3098431fbb02e9d30R52) [[2]](diffhunk://#diff-47b2737085ae43569ca14a3165dc0f465cea7f01e8d786c3098431fbb02e9d30R76)
  - Set `lastActivityAt` to the current timestamp when a user is marked as "AWAY". (`apps/backend/src/gateway/presence/presence.gateway.ts`, [apps/backend/src/gateway/presence/presence.gateway.tsR93](diffhunk://#diff-47b2737085ae43569ca14a3165dc0f465cea7f01e8d786c3098431fbb02e9d30R93))